### PR TITLE
Io worker

### DIFF
--- a/app.go
+++ b/app.go
@@ -678,9 +678,6 @@ ctrl:
 				// FIXME(sbinet) record all of them (errstack)
 				err = eworker
 			}
-			if eworker == io.EOF {
-				app.msg.Infof(">>> got EOF <<<\n")
-			}
 
 		case <-runctx.Done():
 			return runctx.Err()

--- a/app.go
+++ b/app.go
@@ -764,6 +764,14 @@ func (app *appmgr) stop(ctx Context) error {
 	var err error
 	defer app.msg.flush()
 	app.state = fsm.Stopping
+
+	if app.istream != nil {
+		err = app.istream.StopTask(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
 	for i, tsk := range app.tsks {
 		err = tsk.StopTask(app.ctxs[0][i])
 		if err != nil {

--- a/app.go
+++ b/app.go
@@ -53,7 +53,7 @@ func NewApp() App {
 			nil,
 		),
 		evtmax: -1,
-		nprocs: 0,
+		nprocs: -1,
 		comps:  make(map[string]Component),
 		tsks:   make([]Task, 0),
 		svcs:   make([]Svc, 0),

--- a/ctx.go
+++ b/ctx.go
@@ -1,11 +1,17 @@
 package fwk
 
+import (
+	nctx "golang.org/x/net/context"
+)
+
 type context struct {
 	id    int64
 	slot  int
 	store Store
 	msg   msgstream
 	mgr   App
+
+	ctx nctx.Context
 }
 
 func (ctx context) ID() int64 {

--- a/examples/fwk-ex-tuto-1/main.go
+++ b/examples/fwk-ex-tuto-1/main.go
@@ -18,7 +18,7 @@ import (
 var (
 	g_lvl    = flag.String("l", "INFO", "message level (DEBUG|INFO|WARN|ERROR)")
 	g_evtmax = flag.Int64("evtmax", 10, "number of events to process")
-	g_nprocs = flag.Int("nprocs", 0, "number of events to process concurrently")
+	g_nprocs = flag.Int("nprocs", -1, "number of events to process concurrently")
 )
 
 func main() {

--- a/examples/fwk-ex-tuto-2/main.go
+++ b/examples/fwk-ex-tuto-2/main.go
@@ -20,7 +20,7 @@ import (
 var (
 	g_lvl    = flag.String("l", "INFO", "message level (DEBUG|INFO|WARN|ERROR)")
 	g_evtmax = flag.Int64("evtmax", -1, "number of events to process")
-	g_nprocs = flag.Int("nprocs", 0, "number of events to process concurrently")
+	g_nprocs = flag.Int("nprocs", -1, "number of events to process concurrently")
 )
 
 func main() {

--- a/examples/fwk-ex-tuto-3/main.go
+++ b/examples/fwk-ex-tuto-3/main.go
@@ -20,7 +20,7 @@ import (
 var (
 	g_lvl    = flag.String("l", "INFO", "message level (DEBUG|INFO|WARN|ERROR)")
 	g_evtmax = flag.Int64("evtmax", -1, "number of events to process")
-	g_nprocs = flag.Int("nprocs", 0, "number of events to process concurrently")
+	g_nprocs = flag.Int("nprocs", -1, "number of events to process concurrently")
 )
 
 func main() {

--- a/fwk_test.go
+++ b/fwk_test.go
@@ -243,14 +243,6 @@ func TestPortsCycles(t *testing.T) {
 	}
 }
 
-func getsum(n int64) int64 {
-	sum := int64(0)
-	for i := int64(0); i < n; i++ {
-		sum += i
-	}
-	return sum
-}
-
 func getsumsq(n int64) int64 {
 	sum := int64(0)
 	for i := int64(0); i < n; i++ {
@@ -270,7 +262,7 @@ func newTestReader(max int) io.Reader {
 func TestInputStream(t *testing.T) {
 	const max = 1000
 	for _, evtmax := range []int64{0, 1, 10, 100, -1} {
-		for _, nprocs := range []int{0, 1, 2, 4, 8} {
+		for _, nprocs := range []int{0, 1, 2, 4, 8, -1} {
 			nmax := evtmax
 			if nmax < 0 {
 				nmax = max
@@ -309,13 +301,15 @@ func TestInputStream(t *testing.T) {
 				Type: "github.com/go-hep/fwk/testdata.reducer",
 				Name: "reducer",
 				Props: job.P{
-					"Input": "t1-ints1",
-					"Sum":   getsum(nmax),
+					"Input": "t1-ints1-massaged",
+					"Sum":   getsumsq(nmax),
 				},
 			})
 
-			app.Run()
-
+			err := app.App().Run()
+			if err != nil {
+				t.Errorf("error (evtmax=%d nprocs=%d): %v\n", evtmax, nprocs, err)
+			}
 		}
 	}
 }
@@ -323,7 +317,7 @@ func TestInputStream(t *testing.T) {
 func TestOutputStream(t *testing.T) {
 	const max = 1000
 	for _, evtmax := range []int64{0, 1, 10, 100, -1} {
-		for _, nprocs := range []int{0, 1, 2, 4, 8} {
+		for _, nprocs := range []int{0, 1, 2, 4, 8, -1} {
 			nmax := evtmax
 			if nmax < 0 {
 				nmax = max
@@ -369,8 +363,8 @@ func TestOutputStream(t *testing.T) {
 				Type: "github.com/go-hep/fwk/testdata.reducer",
 				Name: "reducer",
 				Props: job.P{
-					"Input": "t1-ints1",
-					"Sum":   getsum(nmax),
+					"Input": "t1-ints1-massaged",
+					"Sum":   getsumsq(nmax),
 				},
 			})
 
@@ -390,7 +384,10 @@ func TestOutputStream(t *testing.T) {
 					},
 				},
 			})
-			app.Run()
+			err = app.App().Run()
+			if err != nil {
+				t.Errorf("error (evtmax=%d nprocs=%d): %v\n", evtmax, nprocs, err)
+			}
 
 			err = w.Close()
 			if err != nil {

--- a/inputstream.go
+++ b/inputstream.go
@@ -77,7 +77,8 @@ func (tsk *InputStream) read() {
 		select {
 
 		case ctx := <-tsk.ctrl.Ctx:
-			tsk.ctrl.Err <- tsk.streamer.Read(ctx)
+			err := tsk.streamer.Read(ctx)
+			tsk.ctrl.Err <- err
 
 		case <-tsk.ctrl.Quit:
 			return
@@ -122,6 +123,24 @@ func newInputStream(typ, name string, mgr App) (Component, error) {
 	}
 
 	return tsk, err
+}
+
+// inputStream provides fake input events when no input file is present
+type inputStream struct {
+	TaskBase
+}
+
+func (tsk *inputStream) StartTask(ctx Context) error {
+	return nil
+}
+
+func (tsk *inputStream) StopTask(ctx Context) error {
+	panic("boo")
+	return nil
+}
+
+func (tsk *inputStream) Process(ctx Context) error {
+	return nil
 }
 
 func init() {

--- a/inputstream.go
+++ b/inputstream.go
@@ -46,6 +46,7 @@ func (tsk *InputStream) StartTask(ctx Context) error {
 func (tsk *InputStream) StopTask(ctx Context) error {
 	var err error
 
+	err = tsk.disconnect()
 	return err
 }
 
@@ -65,10 +66,6 @@ func (tsk *InputStream) connect(ctrl StreamControl) error {
 }
 
 func (tsk *InputStream) disconnect() error {
-	select {
-	case tsk.ctrl.Quit <- struct{}{}:
-	default:
-	}
 	return tsk.streamer.Disconnect()
 }
 
@@ -77,8 +74,7 @@ func (tsk *InputStream) read() {
 		select {
 
 		case ctx := <-tsk.ctrl.Ctx:
-			err := tsk.streamer.Read(ctx)
-			tsk.ctrl.Err <- err
+			tsk.ctrl.Err <- tsk.streamer.Read(ctx)
 
 		case <-tsk.ctrl.Quit:
 			return
@@ -135,7 +131,6 @@ func (tsk *inputStream) StartTask(ctx Context) error {
 }
 
 func (tsk *inputStream) StopTask(ctx Context) error {
-	panic("boo")
 	return nil
 }
 

--- a/outputstream.go
+++ b/outputstream.go
@@ -46,6 +46,7 @@ func (tsk *OutputStream) StartTask(ctx Context) error {
 func (tsk *OutputStream) StopTask(ctx Context) error {
 	var err error
 
+	err = tsk.disconnect()
 	return err
 }
 
@@ -65,10 +66,6 @@ func (tsk *OutputStream) connect(ctrl StreamControl) error {
 }
 
 func (tsk *OutputStream) disconnect() error {
-	select {
-	case tsk.ctrl.Quit <- struct{}{}:
-	default:
-	}
 	return tsk.streamer.Disconnect()
 }
 


### PR DESCRIPTION
    I/O with -nprocs=-1 and -evtmax=-1 used to dead lock.
    This was because the task producing the first data items was "lost"
    among the other tasks.
    When that input stream was hiting the io.EOF of the underlying
    io.Reader, other workers may have already been waiting on the
    "synthetic" chan int64 evts used to prime all workers and tasks.
    
    The new setup is priming the whole graph of tasks by having a single
    app.input-stream task, reading all input data and sending it over a
    'chan context' events.
    Each gang of workers receive from that channel.
    That channel is closed when io.EOF is encountered.
    
    In the case of an application with no input-file (e.g. a Monte-Carlo
    generator job) a dummy input-stream is created.
